### PR TITLE
register core app in django installed-apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.venv/
 **/__pycache__/
 **/migrations/
+.vscode

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    # local apps 
+    'core',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Registered the `core` app in Django's `INSTALLED_APPS` so Django can discover its models, views, and other components
resolves #4 